### PR TITLE
Improve runtime efficiency

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,14 +2,11 @@ module.exports = leftpad;
 
 function leftpad (str, len, ch) {
   str = String(str);
-
   len = len - str.length;
   if (len < 1) return str;
-  
   if (!ch && ch !== 0) ch = ' ';
+
   var arr = new Array(len+1);
-  for(var i=0; i<arr.length; i++)
-    arr[i] = (i == arr.length - 1) ? str : ch;
-    
-  return arr.join('');
+  arr[arr.length - 1] = str;
+  return arr.join(ch);
 }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = leftpad;
 function leftpad (str, len, ch) {
   str = String(str);
   if (!ch && ch !== 0) ch = ' ';
-  
+
   len = len - str.length;
   if (len < 1) return str;
   

--- a/index.js
+++ b/index.js
@@ -2,16 +2,14 @@ module.exports = leftpad;
 
 function leftpad (str, len, ch) {
   str = String(str);
-
-  var i = -1;
-
   if (!ch && ch !== 0) ch = ' ';
-
+  
   len = len - str.length;
-
-  while (++i < len) {
-    str = ch + str;
-  }
-
-  return str;
+  if (len < 1) return str;
+  
+  var arr = new Array(len+1);
+  for(var i=0;i<arr.length;i++)
+    arr[i] = (i == arr.length - 1) ? str : ch;
+    
+  return arr.join('');
 }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function leftpad (str, len, ch) {
   if (len < 1) return str;
   
   var arr = new Array(len+1);
-  for(var i=0;i<arr.length;i++)
+  for(var i=0; i<arr.length; i++)
     arr[i] = (i == arr.length - 1) ? str : ch;
     
   return arr.join('');

--- a/index.js
+++ b/index.js
@@ -2,11 +2,11 @@ module.exports = leftpad;
 
 function leftpad (str, len, ch) {
   str = String(str);
-  if (!ch && ch !== 0) ch = ' ';
 
   len = len - str.length;
   if (len < 1) return str;
   
+  if (!ch && ch !== 0) ch = ' ';
   var arr = new Array(len+1);
   for(var i=0; i<arr.length; i++)
     arr[i] = (i == arr.length - 1) ? str : ch;


### PR DESCRIPTION
using array instead of strings to concatenate the response.
the pattern of `array.join` is much faster than `+=` that actually copy the entire string each time. 
it's better both in terms of memory and runtime. 
sources: 
[airbnb](https://github.com/airbnb/javascript/tree/master/es5#strings) - 

> When programmatically building up a string, use Array#join instead of string concatenation.

also i checked using this test:

``` javascript
var Benchmark = require('benchmark');
var suite = new Benchmark.Suite;

function a (str, len, ch) {
  str = String(str);
  var i = -1;
  if (!ch && ch !== 0) ch = ' ';
  len = len - str.length;
  while (++i < len) {
    str = ch + str;
  }
  return str;
}

function b (str, len, ch) {
  str = String(str);
  len = len - str.length;
  if (len < 1) return str;
  if (!ch && ch !== 0) ch = ' ';
  var arr = new Array(len+1);
  arr[arr.length - 1] = str;
  return arr.join(ch);
}

suite
.add('a', function(){
  a('foo', 5);
  a('foobar', 6);
  a(1, 2, 0);
  a('aksjdasjd aksdjaskdj askdjaksjd askjdaksjdk', 213126);
})
.add('b', function(){
  b('foo', 5);
  b('foobar', 6);
  b(1, 2, 0);
  b('aksjdasjd aksdjaskdj askdjaksjd askjdaksjdk', 213126);
})
.on('cycle', function(event) {
  console.log(String(event.target));
})
.on('complete', function() {
  console.log('Fastest is ' + this.filter('fastest').map('name'));
})
.run({ 'async': true });
```

results are:

```
sagiv:fb sagivo$ node app
a x 130 ops/sec ±3.43% (70 runs sampled)
b x 277 ops/sec ±2.18% (78 runs sampled)
Fastest is b
sagiv:fb sagivo$ node app
a x 137 ops/sec ±2.75% (74 runs sampled)
b x 290 ops/sec ±1.65% (78 runs sampled)
Fastest is b
```
