### PR TITLE
Whitelisted files to be uploaded to npm and used preppublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,16 @@
   "main": "index.js",
   "scripts": {
     "test": "node test",
+    "prepublish": "npm test",
     "bench": "node perf/perf.js"
   },
   "devDependencies": {
     "benchmark": "^2.1.0",
     "tape": "*"
   },
+  "files": [
+    "index.js"
+  ],
   "keywords": [
     "leftpad",
     "left",


### PR DESCRIPTION
Hi ,

This PR changes how package should be handled by `npm` using [`prepublish`](https://docs.npmjs.com/misc/scripts) and [`files`](https://docs.npmjs.com/files/package.json#files) key in `package.json`
- Added `files` keys in package.json that tells npm which files to actually include in npm registry for this        package and for this package only index.js is of end users interest so i whitelisted that file only
- I integrated `npm test` with `prepublish` that tells npm that run npm test before publishing that package to npm

Please review ASAP!
