### PR TITLE
Updated perf test cases

### DIFF
--- a/perf/perf.js
+++ b/perf/perf.js
@@ -32,5 +32,9 @@ var fns = {
   'Current': current
 };
 
-buildSuite('-> len = 100', fns, ['abcd', 100, ' ']).run();
-buildSuite('-> len = 10', fns, ['abcd', 10,  ' ']).run();
+buildSuite('-> pad 100 spaces to str of len 4', fns, ['abcd', 104, ' ']).run();
+buildSuite('-> pad 10 spaces to str of len 4', fns, ['abcd', 14,  ' ']).run();
+buildSuite('-> pad 9 spaces to str of len 4', fns, ['abcd', 13,  ' ']).run();
+buildSuite('-> pad 100 to str of len 100', fns, ['0012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789123456789', 200, ' ']).run();
+buildSuite('-> pad 10 to str of len 100', fns, ['0012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789123456789', 110, ' ']).run();
+buildSuite('-> pad 9 to str of len 100', fns, ['0012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789123456789', 109, ' ']).run();


### PR DESCRIPTION
Updated performance test cases
- updated the padding to 10 and 100 instead of the previous 96 and 6
- added padding of 10 to see the difference in a small but not tuned len
- added tests for longer str

<details>
  <summary>

Click to expand to see output from a sample run in my local.</summary>



```
-> pad 100 spaces to str of len 4
O(n) x 923,782 ops/sec ±0.33% (90 runs sampled)
ES6 Repeat x 5,527,761 ops/sec ±0.52% (89 runs sampled)
Current x 6,178,701 ops/sec ±0.90% (85 runs sampled)
Fastest is Current
-> pad 10 spaces to str of len 4
O(n) x 4,709,152 ops/sec ±0.42% (91 runs sampled)
ES6 Repeat x 7,043,262 ops/sec ±0.47% (87 runs sampled)
Current x 7,715,931 ops/sec ±0.67% (88 runs sampled)
Fastest is Current
-> pad 9 spaces to str of len 4
O(n) x 4,910,730 ops/sec ±0.66% (88 runs sampled)
ES6 Repeat x 7,022,047 ops/sec ±0.61% (88 runs sampled)
Current x 17,276,271 ops/sec ±0.73% (89 runs sampled)
Fastest is Current
-> pad 100 to str of len 100
O(n) x 984,185 ops/sec ±0.62% (90 runs sampled)
ES6 Repeat x 5,621,288 ops/sec ±0.85% (88 runs sampled)
Current x 6,190,708 ops/sec ±0.76% (88 runs sampled)
Fastest is Current
-> pad 10 to str of len 100
O(n) x 6,919,856 ops/sec ±0.63% (91 runs sampled)
ES6 Repeat x 6,973,489 ops/sec ±0.72% (90 runs sampled)
Current x 7,700,710 ops/sec ±0.54% (85 runs sampled)
Fastest is Current
-> pad 9 to str of len 100
O(n) x 7,362,877 ops/sec ±0.65% (89 runs sampled)
ES6 Repeat x 6,992,333 ops/sec ±0.66% (88 runs sampled)
Current x 17,685,511 ops/sec ±0.55% (89 runs sampled)
Fastest is Current
```

</details>

No big difference between `str` of len 100 and 4, though.
