### PR TITLE
Removed unnecessary if check at the end of the es6Repeat implmentation

### DIFF
--- a/perf/es6Repeat.js
+++ b/perf/es6Repeat.js
@@ -9,9 +9,5 @@ module.exports = function (str, len, ch) {
   if (!ch && ch !== 0) ch = ' ';
   ch = ch + '';
 
-  if (len > 0) {
-    return ch.repeat(len) + str;
-  }
-
-  return str;
+  return ch.repeat(len) + str;
 };


### PR DESCRIPTION
There's already a `if (len <= 0)` check above. So `len > 0` would always be true.

That does not seem to improve the perf by a lot though. It happens to fall into the fastest category of conditional branching: http://igoro.com/archive/fast-and-slow-if-statements-branch-prediction-in-modern-processors/
