### PR TITLE
Perf boost

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,13 +6,14 @@
 'use strict';
 module.exports = leftPad;
 
-// Generate cache. Strings are UTF16 in JavaScript, so
-// this will be at most (1 + 2 + … + 32) = 528*2 bytes,
-// or about 1KiB of cache per array (plus a little
-// bit extra overhead). Probably not a significant amount.
-var c = [' '];
+// Generate cache for common use-case of padding with spaces and zeros.
+// JavaScript has UTF16 strings, so worst case this is 2 bytes times
+// 1 + 2 + … + 32 = 528 chars, or about 1KiB per array, plus a few
+// bytes of overhead per string. Probably not a significant amount.
+var c_ = [' '], c0 = ['0'];
 for (var i = 1; i < 32; i++) {
-  c.push(c[i - 1] + ' ');
+  c_.push(c_[i - 1] + ' ');
+  c0.push(c0[i - 1] + '0');
 }
 
 /**
@@ -22,30 +23,32 @@ for (var i = 1; i < 32; i++) {
  * @returns {string}
  */
 function leftPad (str, len, ch) {
-  // force `str` to a `string` via type coercion,
-  // subtract its length from `len` to get proper
+  // Force `str` to a string via type coercion,
+  // subtract `str.length` from `len` to get proper
   // pad length, and return if we don't need to pad
   if (str += '', len -= str.length, len <= 0) return str;
-  // `ch` defaults to `' '`, otherwise coerce it
-  // to a `string` since it could be a number
-  if (!ch && ch !== 0) ch = ' ';
-  else ch += ''; 
-  // common use cases
   var pad = '';
-  if (ch === ' ') {
-    pad = c[len-1 & 31];
+  // `ch` defaults to `' '` for falsy values, except for 0
+  if (ch === ' ' || !ch && ch !== 0){
+    // We use a cache to speed up the default case
+    pad = c_[len-1 & 31];
     if (len <= 32) return pad + str;
-    // `pad` already contains the result of
+    // `pad` effectively contains the result of
     // iterating the loop below five times,
     // so we can skip those.
-    // `ch` is to 32 spaces to accomodate this.
+    // `ch` is set to 32 spaces to accomodate this.
     ch = '                                ';
     len >>= 5;
+  } else if ((ch+= '') === '0'){
+    // padding by zero is another really common use-case
+    pad = c0[len-1 & 31];
+    if (len <= 32) return pad + str;
+    ch = '00000000000000000000000000000000';
+    len >>= 5;
   }
-  // `len` must be non-zero at this point,
-  // and the last iteration through the loop
-  // is guaranteed to be one, meaning we can skip
-  // that last iteration of the while loop entirely.
+  // `len` must be non-zero at this point, and the
+  // last loop iteration is guaranteed to be one,
+  // meaning we can skip testing for it entirely.
   while (len>1) {
     // We essentially apply bitwise multiplication
     // when adding `ch` to `pad`, which means it grows

--- a/index.js
+++ b/index.js
@@ -39,13 +39,13 @@ function leftPad (str, len, ch) {
     // `ch` is set to 32 spaces to accomodate this.
     ch = '                                ';
     len >>= 5;
-  } else if ((ch+= '') === '0'){
+  } else if (ch === 0 || ch === '0'){
     // padding by zero is another really common use-case
     pad = c0[len-1 & 31];
     if (len <= 32) return pad + str;
     ch = '00000000000000000000000000000000';
     len >>= 5;
-  }
+  } else ch += '';
   // `len` must be non-zero at this point, and the
   // last loop iteration is guaranteed to be one,
   // meaning we can skip testing for it entirely.

--- a/index.js
+++ b/index.js
@@ -7,45 +7,65 @@
 module.exports = leftPad;
 
 var cache = [
-  '',
-  ' ',
-  '  ',
-  '   ',
-  '    ',
-  '     ',
-  '      ',
-  '       ',
-  '        ',
-  '         '
+    '',
+    ' ',
+    '  ',
+    '   ',
+    '    ',
+    '     ',
+    '      ',
+    '       ',
+    '        ',
+    '         ',
+    '          ',
+    '           ',
+    '            ',
+    '             ',
+    '              ',
+    '               ',
+    '                ',
+    '                 ',
 ];
 
 function leftPad (str, len, ch) {
-  // convert `str` to a `string`
-  str = str + '';
+  // initialise `pad` as string early - more monomorphic and helps with str coercion
+  var pad = '';
+  // convert `str` to a `string` via type coercion
+  str = str + pad;
   // `len` is the `pad`'s length now
   len = len - str.length;
   // doesn't need to pad
   if (len <= 0) return str;
-  // `ch` defaults to `' '`
+  // `ch` defaults to `' '` otherwise
+  // convert `ch` to a `string` since 
+  // it could be a number
   if (!ch && ch !== 0) ch = ' ';
-  // convert `ch` to a `string` cuz it could be a number
-  ch = ch + '';
-  // cache common use cases
-  if (ch === ' ' && len < 10) return cache[len] + str;
-  // `pad` starts with an empty string
-  var pad = '';
-  // loop
+  else ch = ch + pad; 
+  // common use cases
+  if (ch === ' ') {
+    // if less than 16 we have a ready-made padding
+    if (len < 16) return cache[len] + str;
+    // initialise pad at correct size and
+    // skip the first four iterations
+    // of the loop below
+    pad = cache[len & 15];
+    len >>= 4;
+    ch = '                ';
+  }
   while (true) {
     // add `ch` to `pad` if `len` is odd
-    if (len & 1) pad += ch;
+    if (len & 1) pad = ch + pad;
     // divide `len` by 2, ditch the remainder
-    len >>= 1;
-    // "double" the `ch` so this operation count grows logarithmically on `len`
-    // each time `ch` is "doubled", the `len` would need to be "doubled" too
-    // similar to finding a value in binary search tree, hence O(log(n))
-    if (len) ch += ch;
-    // `len` is 0, exit the loop
-    else break;
+    if (len >>= 1) {
+      // "double" the `ch` so this operation count grows logarithmically on `len`
+      // each time `ch` is "doubled", the `len` would need to be "doubled" too
+      // similar to finding a value in binary search tree, hence O(log(n))
+      ch += ch;
+      // only reached is `len` is not zero, so we can restart loop early
+      continue;
+    }
+    // only reached if `len` is zero, after which we exit the loop
+    break;
   }
   // pad `str`!
   return pad + str;

--- a/index.js
+++ b/index.js
@@ -28,14 +28,11 @@ function leftPad (str, len, ch) {
   if (str += '', len -= str.length, len <= 0) return str;
   // `ch` defaults to `' '`, otherwise coerce it
   // to a `string` since it could be a number
-  if (!ch && ch === 0) ch += '';
-  else ch = ' '; 
+  if (!ch && ch !== 0) ch = ' ';
+  else ch += ''; 
   // common use cases
   var pad = '';
   if (ch === ' ') {
-    // Skip loop entirely when len <= 32.
-    // Note: at this point `len` must be
-    // greater than zero, so `len-1` is safe.
     pad = c[len-1 & 31];
     if (len <= 32) return pad + str;
     // `pad` already contains the result of

--- a/index.js
+++ b/index.js
@@ -6,26 +6,15 @@
 'use strict';
 module.exports = leftPad;
 
-var cache = [
-    '',
-    ' ',
-    '  ',
-    '   ',
-    '    ',
-    '     ',
-    '      ',
-    '       ',
-    '        ',
-    '         ',
-    '          ',
-    '           ',
-    '            ',
-    '             ',
-    '              ',
-    '               ',
-    '                ',
-    '                 ',
-];
+// Generate cache. Strings are UTF16 in JavaScript,
+// so this will be (1 + 2 + … + 32) = 528*2 bytes,
+// or about 1KiB of cache per array (plus a little
+// bit extra overhead). 
+// Probably not a significant amount.
+var cache = ['',' '];
+for (var i = 2; i <= 32; i++){
+  cache.push(cache[i-1]+' ');
+}
 
 function leftPad (str, len, ch) {
   // initialise `pad` as string early - more monomorphic and helps with str coercion
@@ -43,14 +32,14 @@ function leftPad (str, len, ch) {
   else ch = ch + pad; 
   // common use cases
   if (ch === ' ') {
-    // if less than 16 we have a ready-made padding
-    if (len < 16) return cache[len] + str;
+    // if less or equal to 32 we have a ready-made padding
+    if (len <= 32) return cache[len] + str;
     // initialise pad at correct size and
-    // skip the first four iterations
+    // skip the first five iterations
     // of the loop below
-    pad = cache[len & 15];
-    len >>= 4;
-    ch = '                ';
+    pad = cache[len & 31];
+    len >>= 5;
+    ch = cache[32];
   }
   while (true) {
     // add `ch` to `pad` if `len` is odd

--- a/test.js
+++ b/test.js
@@ -8,7 +8,7 @@ var test = require("tape");
 var fc = require("fast-check");
 
 test('edge cases', function (assert) {
-  assert.plan(12);
+  assert.plan(20);
   assert.strictEqual(leftPad('foobar', 6), 'foobar');
   assert.strictEqual(leftPad('foobar', 5), 'foobar');
   assert.strictEqual(leftPad('foobar', -1), 'foobar');
@@ -16,8 +16,15 @@ test('edge cases', function (assert) {
   assert.strictEqual(leftPad('foobar', 5, '1'), 'foobar');
   assert.strictEqual(leftPad('foobar', -1, '1'), 'foobar');
   assert.strictEqual(leftPad('foobar', 8, ''), '  foobar');
+  assert.strictEqual(leftPad('foobar', 8, []), 'foobar', 'passing [] for ch pads with nothing');
   assert.strictEqual(leftPad('foobar', 8, false), '  foobar', 'false default to space');
+  assert.strictEqual(leftPad('foobar', 8, 'false'), 'falsefalsefoobar', '"false" pads with "false"');
+  assert.strictEqual(leftPad('foobar', 8, undefined), '  foobar', 'undefined default to space');
+  assert.strictEqual(leftPad('foobar', 8, 'undefined'), 'undefinedundefinedfoobar', '"undefined" pads with "undefined"');
+  assert.strictEqual(leftPad('foobar', 8, null), '  foobar', 'null default to space');
+  assert.strictEqual(leftPad('foobar', 8, 'null'), 'nullnullfoobar', '"null" pads with "null"');
   assert.strictEqual(leftPad('foobar', 8, 0), '00foobar', '0 is treated as 0');
+  assert.strictEqual(leftPad('foobar', 8, "0"), '00foobar', '"0" is treated as "0"');
   assert.strictEqual(leftPad(0, 3, 1), '110', 'integer for str is converted to string');
   assert.strictEqual(leftPad(true, 7), '   true', 'boolean for str is converted to string');
   assert.strictEqual(leftPad('', 2), '  ', 'empty str for str');

--- a/test.js
+++ b/test.js
@@ -23,8 +23,22 @@ test('edge cases', function (assert) {
   assert.strictEqual(leftPad('', 2), '  ', 'empty str for str');
 });
 
+  var str10 = '          '; // 10 spaces
+  var str100 = str10 + str10; // 20
+  str100 += str100; // 40
+  str100 += str100; // 80
+  str100 += str10 + str10; // 100
+  var str1000 = str100 + str100; // 200
+  str1000 += str1000; // 400
+  str1000 += str1000; // 800
+  str1000 += str100 + str100; // 1000
+  var str10000 = str1000 + str1000; // 2000
+  str10000 += str10000; // 4000
+  str10000 += str10000; // 8000
+  str10000 += str1000 + str1000; // 10000
+
 test('spaces for ch', function (assert) {
-  assert.plan(12);
+  assert.plan(18);
   // default to space if not specified
   assert.strictEqual(leftPad('foo', 2), 'foo');
   assert.strictEqual(leftPad('foo', 3), 'foo');
@@ -32,6 +46,9 @@ test('spaces for ch', function (assert) {
   assert.strictEqual(leftPad('foo', 5), '  foo');
   assert.strictEqual(leftPad('foo', 12), '         foo');
   assert.strictEqual(leftPad('foo', 13), '          foo');
+  assert.strictEqual(leftPad('foo', 103), str100 + 'foo');
+  assert.strictEqual(leftPad('foo', 1003), str1000 + 'foo');
+  assert.strictEqual(leftPad('foo', 10003), str10000 + 'foo');
   // explicit space param
   assert.strictEqual(leftPad('foo', 2, ' '), 'foo');
   assert.strictEqual(leftPad('foo', 3, ' '), 'foo');
@@ -39,6 +56,9 @@ test('spaces for ch', function (assert) {
   assert.strictEqual(leftPad('foo', 5, ' '), '  foo');
   assert.strictEqual(leftPad('foo', 12, ' '), '         foo');
   assert.strictEqual(leftPad('foo', 13, ' '), '          foo');
+  assert.strictEqual(leftPad('foo', 103, ' '), str100 + 'foo');
+  assert.strictEqual(leftPad('foo', 1003, ' '), str1000 + 'foo');
+  assert.strictEqual(leftPad('foo', 10003, ' '), str10000 + 'foo');
 });
 
 test('non spaces for ch', function (assert) {


### PR DESCRIPTION
So I just spent entirely too much time this evening/night trying to make `left-pad` faster, as can be seen by [the number of benchmarks I've created on perf.zone](https://perf.zone/user/tlh545IWtPgS86I7SAF8Qjma6w32):
![leftpad-2](https://user-images.githubusercontent.com/259840/36764219-dac48b8a-1c2b-11e8-85f3-bba14d21e2f3.gif)

After various dead ends (alternate ways of breaking out of the loop, loop unrolling), I finally found a set of tweaks that leads to consistent improvements for longer padding, _without_ reduction in performance when padding only a handful of characters.

There are a few small tweaks that had consistent improvements, like hoisting the padding variable, and switching the order in which `ch` is added to `pad`, because [it turns out](https://run.perf.zone/view/String-concat-does-the-order-matter-1519755302670) to matter [a tiny bit](https://run.perf.zone/view/String-concat-does-the-order-matter-1-190-1519755398884). Furthermore, instead of *breaking out* of the while-loop when `len` is zero, we *continue* it early as long as `len` is greater than zero.

However, the biggest change is very clearly this:

```js
    // ==== OLD ====
    if (ch === ' ' && len < 10) return cache[len] + str;
    var pad = '';
   
    // ==== NEW ====
    if (ch === ' ') {
        if (len < 16) return cache[len] + str;
        pad = cache[len & 15];
        len >>= 4;
        ch = '                ';
    }
```

Expanding the cache let's use skip the while loop when padding 10-15 characters. That's just a side-effect of the code below it, which leads to enormous improvements when padding large numbers of characters: `pad = cache[len & 15];  len >>= 4; ch = '                ';`
This initiates `pad` at the right size to let us skip the first four iterations of the loop. Recall that padding by 256 characters adds up to eight iterations. So this halved the time it takes to do that (minus a little bit of overhead).

Note that this would also work with `pad = cache[len & 7];  len >>= 3; ch = '        ';`, and in fact the benchmarks include that version. As you can see below, the 16-element version gives a much, _much_ higher benefit, and IMO isn't so much oversized as the next step (32 elements) would be.

# Selected, probably-bug-free benchmarks

## neither regression nor improvement
- [pad none](https://run.perf.zone/view/pad-none-leftpad-bugfix-Steve-Maos-baseline-more-variants-1519783877604), 
- [pad 4](https://run.perf.zone/view/pad-4-leftpad-bugfix-Steve-Maos-baseline-more-variants-1519781681326) (run multiple times to see how the "winner" varies each run), 
- [pad 8](https://run.perf.zone/view/pad-8-leftpad-bugfix-Steve-Maos-baseline-more-variants-1519781475410)

## Significant perf boosts

- [pad 12](https://run.perf.zone/view/pad-12-leftpad-bugfix-Steve-Maos-baseline-more-variants-1519781278596) (kind of"cheating", since we bumped the cache size)
- [pad 25](https://run.perf.zone/view/pad-25-leftpad-bugfix-Steve-Maos-baseline-more-variants-1519781088832)
- [pad 50](https://run.perf.zone/view/pad-50-leftpad-bugfix-Steve-Maos-baseline-more-variants-1519780882720)
- [pad 90](https://run.perf.zone/view/pad-90-leftpad-bugfix-Steve-Maos-baseline-more-variants-1519780543048)
- [pad 9001](https://run.perf.zone/view/pad-9001-leftpad-bugfix-Steve-Maos-baseline-more-variants-1519780208772)

# Benchmark measurement gallery

## Chrome (Windows 10 64 bits)
![image](https://user-images.githubusercontent.com/259840/36765268-a4bca89c-1c30-11e8-8f93-f8f91b8e3661.png)

![image](https://user-images.githubusercontent.com/259840/36765275-b0951302-1c30-11e8-8904-e786aa8c0976.png)

![image](https://user-images.githubusercontent.com/259840/36765279-b6a435f2-1c30-11e8-9fb1-73135be472fe.png)

![image](https://user-images.githubusercontent.com/259840/36765283-bcc070c2-1c30-11e8-837e-40150468928d.png)

![image](https://user-images.githubusercontent.com/259840/36766080-8e527768-1c34-11e8-9bd6-10ee986335b7.png)

## Firefox 58 (Windows 10, 64 bits)

![image](https://user-images.githubusercontent.com/259840/36765349-05266a6a-1c31-11e8-8021-25c463ef4bbc.png)

![image](https://user-images.githubusercontent.com/259840/36765343-fd5896dc-1c30-11e8-84df-27cd7b63cb0a.png)

![image](https://user-images.githubusercontent.com/259840/36765333-f4eca0b0-1c30-11e8-87a3-15d529e10754.png)

![image](https://user-images.githubusercontent.com/259840/36765326-ec5db3da-1c30-11e8-9b0e-ca72ed24c2e7.png)

![image](https://user-images.githubusercontent.com/259840/36765899-c735badc-1c33-11e8-8376-d87350649cb9.png)