### PR TITLE
use the String.prototype.padStart if avaiable

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
      * To Public License, Version 2, as published by Sam Hocevar. See
      * http://www.wtfpl.net/ for more details. */
 'use strict';
-module.exports = leftPad;
+module.exports = (typeof ''.padStart === 'function') ? ecmaPadStart : leftPad;
 
 var cache = [
   '',
@@ -49,4 +49,11 @@ function leftPad (str, len, ch) {
   }
   // pad `str`!
   return pad + str;
+}
+
+function ecmaPadStart (str, len, ch) {
+  str = str + '';
+  if (len <= str.length) return str;
+  if (!ch && ch !== 0) ch = ' ';
+  return str.padStart(len, ch);
 }

--- a/perf/ecmaPadStart.js
+++ b/perf/ecmaPadStart.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = function (str, len, ch) {
+  str = str + '';
+  if (len <= str.length) return str;
+  if (!ch && ch !== 0) ch = ' ';
+  return str.padStart(len, ch);
+};

--- a/perf/perf.js
+++ b/perf/perf.js
@@ -1,6 +1,7 @@
 'use strict';
 var oN = require('./O(n)');
 var es6Repeat = require('./es6Repeat');
+var ecmaPadStart = require('./ecmaPadStart');
 var current = require('../');
 
 var Benchmark = require('benchmark');
@@ -29,6 +30,7 @@ function buildSuite (note, fns, args) {
 var fns = {
   'O(n)': oN,
   'ES6 Repeat': es6Repeat,
+  'ECMA-262 string.padStart' : ecmaPadStart,
   'Current': current
 };
 


### PR DESCRIPTION
There was a new leftPad functionality added in the newest ECMA Script version which is supported by node. String.prototype.LeftPad(targetLength [, padString]). My solution differs from #53 in that it leaves the old functionality for node versions which don't support leftPad.

Weirdly enough it is slower than the version with repeat() on my Windows 10 machine with node v8.9.4

Love to hear your feedback.

[benchResultsWin10.txt](https://github.com/stevemao/left-pad/files/1768657/benchResultsWin10.txt)
[testResultsWin10.txt](https://github.com/stevemao/left-pad/files/1768658/testResultsWin10.txt)