### PR TITLE
chore: add typescript namespace declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,3 @@ leftPad(17, 5, 0)
 
 [travis-image]: https://travis-ci.org/stevemao/left-pad.svg?branch=master
 [travis-url]: https://travis-ci.org/stevemao/left-pad
-
-## Typings
-
-Typings copied from [DefinitelyTyped](https://github.com/DefinitelyTyped) defined by [Zlatko Andonovski](https://github.com/Goldsmith42) for convenience.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,9 @@
-// Type definitions for left-pad 1.1
+// Type definitions for left-pad 1.2.0
 // Project: https://github.com/stevemao/left-pad
-// Definitions by: Zlatko Andonovski <https://github.com/Goldsmith42>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Definitions by: Zlatko Andonovski, Andrew Yang, Chandler Fang and Zac Xu
+
 declare function leftPad(str: string|number, len: number, ch?: string|number): string;
+
+declare namespace leftPad { }
 
 export = leftPad;


### PR DESCRIPTION
Add namespace declaration to bypass Angular AOT compilation error.

`Import assignment cannot be used when targeting ECMAScript 2015 modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.`

After this change, to compile with AOT compiler, angular user could import left-pad as below.

```javascript 
import * as leftPad from 'left-pad'
```

It doesn't break existing import statement
```javascript 
import leftPad = require('left-pad')
```
or non-typing import
```typescript 
const leftPad = require('left-pad')
```
